### PR TITLE
Add retention options for stale data

### DIFF
--- a/custom_components/ruuvi/sensor.py
+++ b/custom_components/ruuvi/sensor.py
@@ -197,4 +197,10 @@ class RuuviSensor(Entity):
 
     def update(self):
         self.poller.poll()
-        self._state = self.poller.conditions.get(self.mac_address, {}).get(self.sensor_type)
+        new_state = self.poller.conditions.get(self.mac_address, {}).get(self.sensor_type)
+        if new_state is not None:
+            self._state = new_state
+        else:
+            # We won't update the state. Timestamp should stay the same
+            return
+

--- a/custom_components/ruuvi/sensor.py
+++ b/custom_components/ruuvi/sensor.py
@@ -229,6 +229,6 @@ class RuuviSensor(Entity):
                 self.stale_since = datetime.datetime.now()
             else:
                 elapsed = (datetime.datetime.now() - self.stale_since).total_seconds()
-                if elapsed > max_stale * 60:
+                if elapsed > self.max_stale * 60:
                     # DATA IS STALE
                     self._state = None


### PR DESCRIPTION
In my case, I don't want to show "Temperature: 10°C" if the data has been collected 1 hour ago, and the sensor is out of range. 

However ble is unreliable, and sometimes we don't get the advertisement of sensor for one or two polls. This allows us to configure stale data retention per sensor. 

```
sensor:
  - platform: ruuvi
    resources:
        - mac: 'MA:CA:DD:RE:SS:00'
          name: 'livingroom'
          max_stale_minutes: 5
        
        - mac: 'MA:CA:DD:RE:SS:01'
          name: 'bathroom'
          allow_stale: true
```

Right now the defaults are to not allow stale, and turn the state of the sensor to "None" after 5 minutes

TL:DR:
We want to avoid a value being constant when sensor is unavailable like these
<img width="204" alt="Screenshot 2020-04-12 at 0 19 59" src="https://user-images.githubusercontent.com/5014629/79055160-6feaa580-7c53-11ea-8765-900006a44e3d.png">
At the same time that we want to avoid small gaps in the data like these
<img width="349" alt="Screenshot 2020-04-12 at 0 17 47" src="https://user-images.githubusercontent.com/5014629/79055169-7842e080-7c53-11ea-8d06-80c380538fd3.png">





