### PR TITLE
Fix updated_at to a timezone aware datetime

### DIFF
--- a/custom_components/ruuvi/sensor.py
+++ b/custom_components/ruuvi/sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import TEMP_CELSIUS, PERCENTAGE, PRESSURE_HPA
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import call_later
+from homeassistant.util import dt
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     CONF_FORCE_UPDATE, CONF_MONITORED_CONDITIONS,
@@ -143,13 +144,13 @@ class RuuviSensor(Entity):
 
     def set_state(self, state):
         self._state = state
-        self.update_time = datetime.datetime.now()
+        self.update_time = dt.utcnow()
         _LOGGER.debug(f"Updated {self.update_time} {self.name}: {self.state}")
         self.schedule_update_ha_state()
         call_later(self.hass, EXPIRE_AFTER, self.expire_state_if_old)
 
     def expire_state_if_old(self, delay):
-        state_age_seconds = (datetime.datetime.now() - self.update_time) / datetime.timedelta(seconds=1)
+        state_age_seconds = (dt.utcnow() - self.update_time) / datetime.timedelta(seconds=1)
         if state_age_seconds >= EXPIRE_AFTER:
             _LOGGER.debug(f"{self.name}: Expire state due to age")
             self._state = None


### PR DESCRIPTION
It seems that although the sensors show the correct time, the history graphs do not, having a 2h lag. 

This sounded oddly specific given that I'm in UCT+2 (Helsinki). Then I noticed that we're manually setting the `updated_at` attribute of the sensor since #14 . 

This is a quick work around but it would be maybe better not to mess with some of these internals :)

From here it seems it's better to use all dates in UTC: https://www.home-assistant.io/blog/2015/05/09/utc-time-zone-awareness/
