### PR TITLE
Remove expire if old due to blocking update

### DIFF
--- a/custom_components/ruuvi/sensor.py
+++ b/custom_components/ruuvi/sensor.py
@@ -146,11 +146,3 @@ class RuuviSensor(Entity):
         self.update_time = datetime.datetime.now()
         _LOGGER.debug(f"Updated {self.update_time} {self.name}: {self.state}")
         self.schedule_update_ha_state()
-        call_later(self.hass, EXPIRE_AFTER, self.expire_state_if_old)
-
-    def expire_state_if_old(self, delay):
-        state_age_seconds = (datetime.datetime.now() - self.update_time) / datetime.timedelta(seconds=1)
-        if state_age_seconds >= EXPIRE_AFTER:
-            _LOGGER.debug(f"{self.name}: Expire state due to age")
-            self._state = None
-            self.schedule_update_ha_state()


### PR DESCRIPTION
Ok, I let this run for a full day, and the drift seems to increase with time. As soon as things start everything looks ok, but then a lag starts happening. It's just a couple of minutes at first, but after a full day the history has a couple of hours of lag. Note that the sensor still gets updated, but not the history.

<img width="366" alt="Screen Shot 2021-03-14 at 12 04 42" src="https://user-images.githubusercontent.com/5014629/111064723-4cad2380-84be-11eb-9d95-9a9987f6711d.png">

I ruled out the data not being available because what looks like missing data at first goes away when the "lag" rolls over. 

Right now we're doing things in Sync mode. My theory is that because we make the call_later, the execution of `set_state` gets locked until that is executed later. With recurrent calls, that lag increases by 5 minutes every time we update the sensor.

Again this is a quick fix. It would be great that we would move the component fully to async. And now that we're using the `simple_ruuvitag` callbacks it should be easier. 